### PR TITLE
Add basic support for arrays

### DIFF
--- a/src/compiler/compileFunctionDef.ts
+++ b/src/compiler/compileFunctionDef.ts
@@ -5,6 +5,7 @@ import { compileBlkStmt } from './compileStmt'
 import { FunctionCTE, GlobalCTE, VariableInfo } from './compileTimeEnv'
 import { CompileTimeError } from './error'
 import { MICROCODE } from './microcode'
+import { getIdentSize } from './util'
 
 /**
  * Compiles a function declaration node into a `FunctionCTE` object and adds it to the global compile-time environment.
@@ -66,7 +67,8 @@ function countLocalVarSize(stmts: es.Statement[]): number {
   let sum = 0
   for (const stmt of stmts) {
     if (stmt.type === 'VariableDeclaration') {
-      sum += WORD_SIZE // TODO: Consider arrays and structs too
+      const id = stmt.declarations[0].id as es.Identifier
+      sum += getIdentSize(id) // TODO: Consider structs too
     }
 
     if (stmt.type === 'BlockStatement') {

--- a/src/compiler/compileFunctionDef.ts
+++ b/src/compiler/compileFunctionDef.ts
@@ -5,7 +5,7 @@ import { compileBlkStmt } from './compileStmt'
 import { FunctionCTE, GlobalCTE, VariableInfo } from './compileTimeEnv'
 import { CompileTimeError } from './error'
 import { MICROCODE } from './microcode'
-import { getIdentSize } from './util'
+import { getIdentifierSize } from './util'
 
 /**
  * Compiles a function declaration node into a `FunctionCTE` object and adds it to the global compile-time environment.
@@ -68,7 +68,7 @@ function countLocalVarSize(stmts: es.Statement[]): number {
   for (const stmt of stmts) {
     if (stmt.type === 'VariableDeclaration') {
       const id = stmt.declarations[0].id as es.Identifier
-      sum += getIdentSize(id) // TODO: Consider structs too
+      sum += getIdentifierSize(id) // TODO: Consider structs too
     }
 
     if (stmt.type === 'BlockStatement') {

--- a/src/compiler/compileGlobalVarDef.ts
+++ b/src/compiler/compileGlobalVarDef.ts
@@ -6,13 +6,13 @@ import { compileExpr } from './compileExpr'
 import { GlobalCTE } from './compileTimeEnv'
 import { CompileTimeError } from './error'
 import { MICROCODE } from './microcode'
-import { getIdentSize } from './util'
+import { getIdentifierSize } from './util'
 
 export function compileGlobalVarDef(stmt: es.VariableDeclaration, gEnv: GlobalCTE): void {
   for (const declaration of stmt.declarations) {
     if (declaration.id.type !== 'Identifier') throw new CompileTimeError()
     const { name, typeList } = declaration.id
-    const variableInfo = gEnv.addVar(name, typeList, getIdentSize(declaration.id))
+    const variableInfo = gEnv.addVar(name, typeList, getIdentifierSize(declaration.id))
     if (!declaration.init) {
       continue
     }

--- a/src/compiler/compileGlobalVarDef.ts
+++ b/src/compiler/compileGlobalVarDef.ts
@@ -6,12 +6,13 @@ import { compileExpr } from './compileExpr'
 import { GlobalCTE } from './compileTimeEnv'
 import { CompileTimeError } from './error'
 import { MICROCODE } from './microcode'
+import { getIdentSize } from './util'
 
 export function compileGlobalVarDef(stmt: es.VariableDeclaration, gEnv: GlobalCTE): void {
   for (const declaration of stmt.declarations) {
     if (declaration.id.type !== 'Identifier') throw new CompileTimeError()
     const { name, typeList } = declaration.id
-    const variableInfo = gEnv.addVar(name, typeList)
+    const variableInfo = gEnv.addVar(name, typeList, getIdentSize(declaration.id))
     if (!declaration.init) {
       continue
     }

--- a/src/compiler/compileStmt.ts
+++ b/src/compiler/compileStmt.ts
@@ -6,6 +6,7 @@ import { compileExpr } from './compileExpr'
 import { FunctionCTE, getVar, GlobalCTE } from './compileTimeEnv'
 import { CompileTimeError } from './error'
 import { MICROCODE } from './microcode'
+import { getIdentSize } from './util'
 
 /**
  * Represents a statement that needs to be patched.
@@ -128,7 +129,7 @@ function compileVarDef(stmt: es.VariableDeclaration, fEnv: FunctionCTE, gEnv: Gl
     if (declaration.id.type !== 'Identifier') throw new CompileTimeError()
 
     const { name, typeList } = declaration.id
-    const v = fEnv.addVar(name, typeList)
+    const v = fEnv.addVar(name, typeList, getIdentSize(declaration.id))
 
     if (!declaration.init) {
       continue

--- a/src/compiler/compileStmt.ts
+++ b/src/compiler/compileStmt.ts
@@ -6,7 +6,7 @@ import { compileExpr, loadMemoryAddressOfArrayAccess } from './compileExpr'
 import { FunctionCTE, getVar, GlobalCTE } from './compileTimeEnv'
 import { CompileTimeError } from './error'
 import { MICROCODE } from './microcode'
-import { getIdentSize, isArrayAccess } from './util'
+import { getIdentifierSize, isArrayAccess } from './util'
 
 /**
  * Represents a statement that needs to be patched.
@@ -145,7 +145,7 @@ function compileVarDef(stmt: es.VariableDeclaration, fEnv: FunctionCTE, gEnv: Gl
 
     const ident = declaration.id
     const { name, typeList } = ident
-    const v = fEnv.addVar(name, typeList, getIdentSize(ident))
+    const v = fEnv.addVar(name, typeList, getIdentifierSize(ident))
 
     // Case 1: Simple variable
     // - Compile the init expression

--- a/src/compiler/compileTimeEnv.ts
+++ b/src/compiler/compileTimeEnv.ts
@@ -147,11 +147,11 @@ export class FunctionCTE {
    *
    * @throws {CompileTimeError} If the variable already exists in the current frame.
    */
-  addVar(name: string, typeList: es.TypeList): VariableInfo {
+  addVar(name: string, typeList: es.TypeList, varSize: number): VariableInfo {
     const v = {
       name,
       typeList,
-      offset: this.allocNBytesOnStack(WORD_SIZE)
+      offset: this.allocNBytesOnStack(varSize)
     }
 
     const lastFrame = this.frames[this.frames.length - 1]
@@ -250,8 +250,8 @@ export class GlobalCTE {
     throw new CompileTimeError(`error: '${sym}' undeclared`)
   }
 
-  addVar(sym: string, typeList: es.TypeList): VariableInfo {
-    const variableAddress = this.allocateNBytesOnStack(WORD_SIZE)
+  addVar(sym: string, typeList: es.TypeList, varSize: number): VariableInfo {
+    const variableAddress = this.allocateNBytesOnStack(varSize)
     const varInfo = {
       name: sym,
       typeList,

--- a/src/compiler/microcode.ts
+++ b/src/compiler/microcode.ts
@@ -72,11 +72,11 @@ export const MICROCODE = {
     op: op
   }),
 
-  leal: (from: RegOffset, to: RegOffset): LeaCommand => ({
+  leal: (value: RegOffset, to: RegOffset): LeaCommand => ({
     type: 'LeaCommand',
     value: {
-      reg: from[0],
-      offset: from[1]
+      reg: value[0],
+      offset: value[1]
     },
     dest: {
       reg: to[0],

--- a/src/compiler/typeChecker.ts
+++ b/src/compiler/typeChecker.ts
@@ -1,0 +1,204 @@
+import * as es from 'estree'
+
+import { DataType } from '../typings/datatype'
+import { CompileType, FunctionCTE, getFxDecl, getVar, GlobalCTE } from './compileTimeEnv'
+import { CompileTimeError } from './error'
+
+/**
+ * Returns type information about the given expression.
+ */
+export function getExprType(node: es.Expression, gEnv: GlobalCTE, fEnv?: FunctionCTE): CompileType {
+  if (fEnv) {
+    if (node.type === 'MemberExpression') {
+      throw new CompileTimeError() // TODO: implement for array and struct
+    }
+
+    if (node.type === 'CallExpression') {
+      const callee = node.callee
+
+      if (callee.type !== 'Identifier') throw new CompileTimeError()
+      const functionInfo = getFxDecl(callee.name, gEnv)
+      const returnType = functionInfo.returnType
+
+      return {
+        t: returnType[returnType.length - 1] as DataType,
+        typeList: returnType
+      }
+    }
+
+    if (node.type === 'SequenceExpression') {
+      throw new CompileTimeError() // TODO: implement for array and struct
+    }
+
+    if (node.type === 'DereferenceExpression') {
+      const t = getExprType(node.expression, gEnv, fEnv)
+
+      throwIfNotPointer([t])
+
+      // Remove the top most * in the pointerList
+      // To reflect that one 'hop' has been done
+      return {
+        ...t,
+        typeList: t.typeList.slice(1, t.typeList.length)
+      }
+    }
+
+    if (node.type === 'ConditionalExpression') {
+      throw new CompileTimeError() // TODO
+    }
+
+    if (node.type === 'CastExpression') {
+      throw new CompileTimeError() // TODO
+    }
+
+    if (node.type === 'UpdateExpression') {
+      const ident = node.argument
+      if (ident.type !== 'Identifier') throw new CompileTimeError()
+      const [, varInfo] = getVar(ident.name, fEnv, gEnv)
+
+      return {
+        t: varInfo.typeList[varInfo.typeList.length - 1] as DataType,
+        typeList: varInfo.typeList
+      }
+    }
+
+    if (node.type === 'Identifier') {
+      const [, varInfo] = getVar(node.name, fEnv, gEnv)
+      return {
+        t: varInfo.typeList[varInfo.typeList.length - 1] as DataType,
+        typeList: varInfo.typeList
+      }
+    }
+  }
+
+  if (node.type === 'Literal') {
+    return getLiteralType(node)
+  }
+
+  if (node.type === 'LogicalExpression') {
+    // Logical expressions just return 1 or 0
+    return {
+      t: DataType.LONG,
+      typeList: [DataType.LONG]
+    }
+  }
+
+  if (node.type === 'BinaryExpression') {
+    const typeofLeft = getExprType(node.left, gEnv, fEnv)
+    const typeofRight = getExprType(node.right, gEnv, fEnv)
+
+    const isLeftAPtr = isPointer(typeofLeft.typeList)
+    const isRightAPtr = isPointer(typeofRight.typeList)
+
+    if (isLeftAPtr && isRightAPtr) {
+      // if they are both pointers, it is not allowed
+      throw new CompileTimeError()
+    } else if (isLeftAPtr || isRightAPtr) {
+      // if either one is a pointer
+      // return the ptr's type
+      return isLeftAPtr ? typeofLeft : typeofRight
+    } else {
+      // if both are not pointers
+      // return the bigger type
+      // e.g. int + long should return a long
+      return getBiggerType(typeofLeft, typeofRight)
+    }
+  }
+
+  if (node.type === 'SizeofExpression') {
+    throw new CompileTimeError() // TODO: to implement
+  }
+
+  if (node.type === 'AddressofExpression') {
+    const exprType = getExprType(node.expression, gEnv, fEnv)
+
+    // Append an additional * to the typelist
+    // to indicate memory address
+    return {
+      ...exprType,
+      typeList: ['*', ...exprType.typeList]
+    }
+  }
+
+  if (node.type === 'UnaryExpression') {
+    if (node.operator === '!') {
+      // Logical expressions just return 1 or 0
+      return {
+        t: DataType.LONG,
+        typeList: [DataType.LONG]
+      }
+    } else {
+      // Refers to the '-' operator
+      const exprType = getExprType(node.argument, gEnv, fEnv)
+      return exprType
+    }
+  }
+
+  throw new CompileTimeError()
+}
+
+export function isPointer(ls: es.TypeList): boolean {
+  return ls[0] === '*'
+}
+
+export function throwIfNotPointer(ls: CompileType[]): void {
+  ls.forEach(e => {
+    if (!isPointer(e.typeList)) throw new CompileTimeError()
+  })
+}
+
+export function getBiggerType(t1: CompileType, t2: CompileType): CompileType {
+  const RANKING = [DataType.CHAR, DataType.SHORT, DataType.INT, DataType.LONG]
+  const assignRanking = (t: DataType) => RANKING.indexOf(t)
+
+  const t1Rank = assignRanking(t1.t)
+  const t2Rank = assignRanking(t2.t)
+
+  return t1Rank >= t2Rank ? t1 : t2
+}
+
+function getLiteralType(node: es.Literal): CompileType {
+  const isStrLiteral = (input: string) => input.charAt(0) === '"'
+
+  if (typeof node.value === 'number') {
+    return {
+      // Return the largest possible
+      // primitive type
+      t: DataType.LONG,
+      typeList: [DataType.LONG]
+    }
+  }
+
+  if (node.raw && isStrLiteral(node.raw)) {
+    return {
+      t: DataType.CHAR,
+      typeList: ['*', DataType.CHAR]
+    }
+  }
+
+  throw new CompileTimeError()
+}
+
+/**
+ * Checks if the binary expression meets the
+ * type requirements.
+ *
+ * For +/-, allow if one side is a pointer,
+ * the other side is normal.
+ *
+ * For all other operators, only allow if
+ * both sides are normal.
+ */
+export function isBinaryExprAllowed(
+  operator: string,
+  left: CompileType,
+  right: CompileType
+): boolean {
+  if (['+', '-'].includes(operator)) {
+    const areBothPointers = isPointer(left.typeList) && isPointer(right.typeList)
+    return !areBothPointers
+  } else {
+    const areAnyPointers = isPointer(left.typeList) || isPointer(right.typeList)
+    return !areAnyPointers
+  }
+}

--- a/src/compiler/typeChecker.ts
+++ b/src/compiler/typeChecker.ts
@@ -10,7 +10,18 @@ import { CompileTimeError } from './error'
 export function getExprType(node: es.Expression, gEnv: GlobalCTE, fEnv?: FunctionCTE): CompileType {
   if (fEnv) {
     if (node.type === 'MemberExpression') {
-      throw new CompileTimeError() // TODO: implement for array and struct
+      if (node.computed) {
+        // array acccess
+        const arrayObj = node.object as es.Identifier
+        const [, varInfo] = getVar(arrayObj.name, fEnv, gEnv)
+        const { typeList } = varInfo
+        return {
+          t: typeList[typeList.length - 1] as DataType,
+          typeList: typeList
+        }
+      }
+
+      throw new CompileTimeError() // TODO: implement for struct
     }
 
     if (node.type === 'CallExpression') {

--- a/src/compiler/typeChecker.ts
+++ b/src/compiler/typeChecker.ts
@@ -158,6 +158,23 @@ export function throwIfNotPointer(ls: CompileType[]): void {
   })
 }
 
+/**
+ * This function is meant to simplify the type checking when
+ * a binary operator is applied onto 2 normal/primitive types.
+ *
+ * For example, if we have an `int x` and `long y`,
+ * `x+y` is permitted.
+ *
+ * What this function does is that it compares 2 types, and returns the
+ * one that is "bigger". The type of a binary expression between 2 different
+ * types is the type that is bigger - or implying that the "smaller" type
+ * has been type-casted/extended to bigger one.
+ *
+ * In the example above, `x+y` is of the type `long` - `int x` is considered
+ * to be (safely) casted to `long`.
+ *
+ * The concept of "bigger" uses a ranking system of each type.
+ */
 export function getBiggerType(t1: CompileType, t2: CompileType): CompileType {
   const RANKING = [DataType.CHAR, DataType.SHORT, DataType.INT, DataType.LONG]
   const assignRanking = (t: DataType) => RANKING.indexOf(t)
@@ -168,6 +185,10 @@ export function getBiggerType(t1: CompileType, t2: CompileType): CompileType {
   return t1Rank >= t2Rank ? t1 : t2
 }
 
+/**
+ * Given a literal node in the AST (like 3 or "hello"),
+ * check if it is a number or a string.
+ */
 function getLiteralType(node: es.Literal): CompileType {
   const isStrLiteral = (input: string) => input.charAt(0) === '"'
 

--- a/src/compiler/util.ts
+++ b/src/compiler/util.ts
@@ -1,4 +1,4 @@
-import { Identifier, TypeList } from 'estree'
+import { Identifier, MemberExpression, TypeList } from 'estree'
 
 import { WORD_SIZE } from './../constants'
 import { CompileTimeError } from './error'
@@ -50,4 +50,11 @@ export function getIdentSize(ident: Identifier): number {
   } else {
     return unitSize
   }
+}
+
+/**
+ * Checks if a es.MemberExpression is an array access.
+ */
+export function isArrayAccess(node: MemberExpression): boolean {
+  return node.computed
 }

--- a/src/compiler/util.ts
+++ b/src/compiler/util.ts
@@ -26,7 +26,7 @@ export function getUpdateSize(typeList: TypeList): number {
 /**
  * Returns the size of an identifier.
  */
-export function getIdentSize(ident: Identifier): number {
+export function getIdentifierSize(ident: Identifier): number {
   const unitSize: number = WORD_SIZE
 
   if (ident.structFields) {

--- a/src/compiler/util.ts
+++ b/src/compiler/util.ts
@@ -1,6 +1,7 @@
-import { TypeList } from 'estree'
+import { Identifier, TypeList } from 'estree'
 
 import { WORD_SIZE } from './../constants'
+import { CompileTimeError } from './error'
 
 /**
  * Given a certain variable's type, determines how much to update
@@ -20,4 +21,33 @@ export function getUpdateSize(typeList: TypeList): number {
   }
 
   return 1
+}
+
+/**
+ * Returns the size of an identifier.
+ */
+export function getIdentSize(ident: Identifier): number {
+  const unitSize: number = WORD_SIZE
+
+  if (ident.structFields) {
+    // Structs are not supported
+    throw new CompileTimeError()
+  }
+
+  if (ident.isArray) {
+    const size = ident.arraySize
+    if (!size) {
+      // Parser is misconfigured
+      throw new CompileTimeError()
+    }
+
+    // We need 1 more than the declared array size
+    // because the array itself is a pointer
+    // i.e. in `int x[3]`
+    // - x is a pointer to x[0]
+    // -x[i] is the actual data
+    return (size + 1) * unitSize
+  } else {
+    return unitSize
+  }
 }

--- a/src/parser/__tests__/__snapshots__/declaration.ts.snap
+++ b/src/parser/__tests__/__snapshots__/declaration.ts.snap
@@ -738,7 +738,7 @@ Object {
   },
   "declaredStrings": Array [],
   "declaredStructDefinitions": Object {},
-  "globalVariableSize": 8,
+  "globalVariableSize": 32,
 }
 `;
 
@@ -829,7 +829,7 @@ Object {
   },
   "declaredStrings": Array [],
   "declaredStructDefinitions": Object {},
-  "globalVariableSize": 8,
+  "globalVariableSize": 32,
 }
 `;
 
@@ -889,7 +889,7 @@ Object {
   },
   "declaredStrings": Array [],
   "declaredStructDefinitions": Object {},
-  "globalVariableSize": 8,
+  "globalVariableSize": 32,
 }
 `;
 

--- a/src/parser/__tests__/__snapshots__/declaration.ts.snap
+++ b/src/parser/__tests__/__snapshots__/declaration.ts.snap
@@ -646,7 +646,9 @@ Object {
         "declarations": Array [
           Object {
             "id": Object {
+              "arraySize": 3,
               "datatype": "int",
+              "isArray": true,
               "name": "x",
               "type": "Identifier",
               "typeList": Array [
@@ -750,6 +752,7 @@ Object {
             "id": Object {
               "arraySize": 3,
               "datatype": "int",
+              "isArray": true,
               "name": "x",
               "type": "Identifier",
               "typeList": Array [
@@ -840,6 +843,7 @@ Object {
             "id": Object {
               "arraySize": 3,
               "datatype": "int",
+              "isArray": true,
               "name": "x",
               "type": "Identifier",
               "typeList": Array [

--- a/src/parser/__tests__/__snapshots__/sampleProgram.ts.snap
+++ b/src/parser/__tests__/__snapshots__/sampleProgram.ts.snap
@@ -500,7 +500,9 @@ Object {
               "declarations": Array [
                 Object {
                   "id": Object {
+                    "arraySize": 3,
                     "datatype": "int",
+                    "isArray": true,
                     "name": "list",
                     "type": "Identifier",
                     "typeList": Array [
@@ -1015,6 +1017,7 @@ Object {
                   "id": Object {
                     "arraySize": 3,
                     "datatype": "int",
+                    "isArray": true,
                     "name": "list",
                     "type": "Identifier",
                     "typeList": Array [
@@ -1418,6 +1421,7 @@ Object {
                   "id": Object {
                     "arraySize": 3,
                     "datatype": "int",
+                    "isArray": true,
                     "name": "list",
                     "type": "Identifier",
                     "typeList": Array [

--- a/src/parser/visitor.ts
+++ b/src/parser/visitor.ts
@@ -248,21 +248,31 @@ export class Visitor implements SourCParser2Visitor<es.Node> {
     const c = ctx.Constant()
     let size: number | undefined
     if (c !== undefined && !isNaN(parseInt(c.text))) {
+      // Gets the size of the array using the LHS of
+      // the declaration.
       size = parseInt(c.text)
       const id = v.declarations[0].id as es.Identifier
       id.arraySize = size
     }
 
     if (ctx.exprLs()) {
+      // Parse the RHS expressions if any
+      // Note that the size declared on the LHS
+      // takes precedence.
+      // E.g int x[2] = {1, 2, 3, 4};
+      // Should only take 1, 2 from the RHS
+
       let expressions = ctx
         .exprLs()!
         .seqExprLs()
         ._eLs.map(e => this.visit(e) as es.Expression)
 
       if (size !== undefined && size > expressions.length) {
-        // E.g int x[2] = {1, 2, 3, 4};
-        // Should only take 1, 2 from the RHS
         expressions = expressions.slice(0, size)
+      }
+
+      if (size === undefined) {
+        size = expressions.length
       }
 
       v.declarations[0].init = {
@@ -271,11 +281,12 @@ export class Visitor implements SourCParser2Visitor<es.Node> {
       }
     }
 
-    if (size === undefined && !ctx.exprLs()) {
+    if (size === undefined) {
       // The size cannot be determined
       throw new FatalSyntaxError(contextToLocation(ctx))
     }
 
+    setArrayAttributes(v, size)
     return v
   }
 
@@ -869,4 +880,15 @@ function validateExprTypes(nodes: es.Node[], types: string[]): boolean {
     }
   }
   return false
+}
+
+/**
+ * Sets the necessary attributes for arrays in the
+ * given variableDeclaration.
+ */
+function setArrayAttributes(v: es.VariableDeclaration, size: number): void {
+  const id = v.declarations[0].id as es.Identifier
+
+  id.isArray = true
+  id.arraySize = size
 }

--- a/src/parser/visitor.ts
+++ b/src/parser/visitor.ts
@@ -4,7 +4,7 @@ import { RuleNode } from 'antlr4ts/tree/RuleNode'
 import { TerminalNode } from 'antlr4ts/tree/TerminalNode'
 import * as es from 'estree'
 
-import { getIdentSize } from '../compiler/util'
+import { getIdentifierSize } from '../compiler/util'
 import { WORD_SIZE } from '../constants'
 import {
   AddContext,
@@ -845,7 +845,7 @@ export class Visitor implements SourCParser2Visitor<es.Node> {
         return
       }
       // TODO: Consider structs too
-      count += getIdentSize(d.id)
+      count += getIdentifierSize(d.id)
     })
     return count
   }

--- a/src/parser/visitor.ts
+++ b/src/parser/visitor.ts
@@ -4,6 +4,7 @@ import { RuleNode } from 'antlr4ts/tree/RuleNode'
 import { TerminalNode } from 'antlr4ts/tree/TerminalNode'
 import * as es from 'estree'
 
+import { getIdentSize } from '../compiler/util'
 import { WORD_SIZE } from '../constants'
 import {
   AddContext,
@@ -267,7 +268,7 @@ export class Visitor implements SourCParser2Visitor<es.Node> {
         .seqExprLs()
         ._eLs.map(e => this.visit(e) as es.Expression)
 
-      if (size !== undefined && size > expressions.length) {
+      if (size !== undefined && expressions.length > size) {
         expressions = expressions.slice(0, size)
       }
 
@@ -843,8 +844,8 @@ export class Visitor implements SourCParser2Visitor<es.Node> {
       if (d.id.type !== 'Identifier') {
         return
       }
-      // TODO: Consider arrays and structs too
-      count += WORD_SIZE
+      // TODO: Consider structs too
+      count += getIdentSize(d.id)
     })
     return count
   }


### PR DESCRIPTION
Add basic support for arrays.

```C
int main() {
    int i;
    int x[5];
    
    for (i = 0; i < 5; i++) {
        x[i] = i;
    }
    
    // returns 4 * 3 = 12
    return x[4] * x[3];
}
```

Arrays are handled in this manner:

Example: `int x[3]`.
This takes up 4 slots.
- The first slot refers to x. It holds a memory address that points to x[0]
- After that, then comes x[0], x[1], ...

Closes #20