### PR TITLE
fix: Boolean operators `!`, `&&`, `||` to follow C specs

### DIFF
--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -243,10 +243,10 @@ const MACHINE: { [microcode: string]: EvaluatorFunction } = {
         res = BigInt(arg1 !== arg2)
         break
       case '||':
-        res = BigInt(arg1 || arg2)
+        res = (arg1 || arg2) ? BigInt(1) : BigInt(0)
         break
       case '&&':
-        res = BigInt(arg1 && arg2)
+        res = (arg1 && arg2) ? BigInt(1) : BigInt(0)
         break
     }
     dataview.setBytesAt(calculateAddress(ctx, StackPointer, -WORD_SIZE * 2), res)
@@ -272,7 +272,7 @@ const MACHINE: { [microcode: string]: EvaluatorFunction } = {
     let res = arg
     switch (op) {
       case '!':
-        res = BigInt(!res)
+        res = !res ? BigInt(1) : BigInt(0)
         break
       case '-':
         res = -res


### PR DESCRIPTION
- Implement VM logic to ensure boolean operators return 0 or 1